### PR TITLE
[AH-21] 헤이영 메인페이지 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
+dev-dist
 dist-ssr
 *.local
 .env

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "axios": "^1.11.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
+        "react-router-dom": "^7.8.2",
         "vite-plugin-pwa": "^1.0.3"
       },
       "devDependencies": {
@@ -3044,6 +3045,15 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/core-js-compat": {
       "version": "3.45.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.45.0.tgz",
@@ -5179,6 +5189,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.8.2.tgz",
+      "integrity": "sha512-7M2fR1JbIZ/jFWqelpvSZx+7vd7UlBTfdZqf6OSdF9g6+sfdqJDAWcak6ervbHph200ePlu+7G8LdoiC3ReyAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.8.2.tgz",
+      "integrity": "sha512-Z4VM5mKDipal2jQ385H6UBhiiEDlnJPx6jyWsTYoZQdl5TrjxEV2a9yl3Fi60NBJxYzOTGTTHXPi0pdizvTwow==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.8.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -5459,6 +5507,12 @@
       "dependencies": {
         "randombytes": "^2.1.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "axios": "^1.11.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-router-dom": "^7.8.2",
     "vite-plugin-pwa": "^1.0.3"
   },
   "devDependencies": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,22 +1,12 @@
-import React, { useEffect } from 'react';
-import Header from './components/Header/Header';
-import Main from './components/Main/Main';
+import React from 'react';
 import './App.css';
-import { getStoresByCategory } from './util/ddangApi';
+import AppRoutes from './routes/AppRoutes';
 
 
 function App() {
-
-  useEffect(() => {
-    getStoresByCategory("36.11176327871577", "03", "128.42631888739962", "4719067000").then(response => {
-      console.log(response);
-    });
-  }, []);
-
   return (
     <div className="App">
-      <Header />
-      <Main />  
+      <AppRoutes />
     </div>
   );
 }

--- a/src/components/BottomNavigation/BottomNavigation.jsx
+++ b/src/components/BottomNavigation/BottomNavigation.jsx
@@ -1,0 +1,96 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import styles from './BottomNavigation.module.css';
+
+const BottomNavigation = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [activeTab, setActiveTab] = useState('전체메뉴');
+
+  // URL에 따라 활성 탭 설정
+  useEffect(() => {
+    switch (location.pathname) {
+      case '/pay':
+        setActiveTab('페이');
+        break;
+      default:
+        setActiveTab('학사');
+    }
+  }, [location.pathname]);
+
+  const handleNavClick = (item) => {
+    setActiveTab(item.label);
+    
+    switch (item.label) {
+      case '페이':
+        navigate('/pay');
+        break;
+      default:
+        navigate('/');
+    }
+  };
+
+  const navItems = [
+    { 
+      id: 'academic',
+      label: '학사',
+      icon: (isActive) => (
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+          <path d="M22 10v6M2 10l10-5 10 5-10 5z" stroke={isActive ? '#6366f1' : '#999'} strokeWidth="2" strokeLinejoin="round"/>
+          <path d="M6 12v5c3 3 9 3 12 0v-5" stroke={isActive ? '#6366f1' : '#999'} strokeWidth="2" strokeLinejoin="round"/>
+        </svg>
+      )
+    },
+    { 
+      id: 'benefits',
+      label: '혜택',
+      icon: (isActive) => (
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+          <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" 
+                stroke={isActive ? '#6366f1' : '#999'} strokeWidth="2" fill={isActive ? '#6366f1' : 'none'}/>
+        </svg>
+      )
+    },
+    { 
+      id: 'pay',
+      label: '페이',
+      icon: (isActive) => (
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+          <rect x="1" y="4" width="22" height="16" rx="2" ry="2" stroke={isActive ? '#6366f1' : '#999'} strokeWidth="2"/>
+          <line x1="1" y1="10" x2="23" y2="10" stroke={isActive ? '#6366f1' : '#999'} strokeWidth="2"/>
+        </svg>
+      )
+    },
+    { 
+      id: 'all-menu',
+      label: '전체메뉴',
+      icon: (isActive) => (
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+          <rect x="3" y="3" width="6" height="6" rx="1" stroke={isActive ? '#6366f1' : '#999'} strokeWidth="2" fill={isActive ? '#6366f1' : 'none'}/>
+          <rect x="15" y="3" width="6" height="6" rx="1" stroke={isActive ? '#6366f1' : '#999'} strokeWidth="2" fill={isActive ? '#6366f1' : 'none'}/>
+          <rect x="3" y="15" width="6" height="6" rx="1" stroke={isActive ? '#6366f1' : '#999'} strokeWidth="2" fill={isActive ? '#6366f1' : 'none'}/>
+          <rect x="15" y="15" width="6" height="6" rx="1" stroke={isActive ? '#6366f1' : '#999'} strokeWidth="2" fill={isActive ? '#6366f1' : 'none'}/>
+        </svg>
+      )
+    }
+  ];
+
+  return (
+    <div className={styles.bottomNavigation}>
+      {navItems.map((item) => (
+        <div
+          key={item.id}
+          className={`${styles.navItem} ${activeTab === item.label ? styles.active : ''}`}
+          onClick={() => handleNavClick(item)}
+        >
+          <div className={styles.navIcon}>
+            {item.icon(activeTab === item.label)}
+          </div>
+          <span className={styles.navLabel}>{item.label}</span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default BottomNavigation;

--- a/src/components/BottomNavigation/BottomNavigation.module.css
+++ b/src/components/BottomNavigation/BottomNavigation.module.css
@@ -1,0 +1,59 @@
+.bottomNavigation {
+  position: fixed;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100%;
+  height: 80px;
+  background: white;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  border-top: 1px solid #f0f0f0;
+  padding: 8px 0 20px 0;
+  box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.1);
+}
+
+.navItem {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  cursor: pointer;
+  padding: 8px 12px;
+  border-radius: 8px;
+  transition: all 0.2s ease;
+  flex: 1;
+}
+
+.navItem:hover {
+  background: #f8f9fa;
+}
+
+.navIcon {
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.navLabel {
+  font-size: 11px;
+  font-weight: 500;
+  color: #999;
+  transition: color 0.2s ease;
+}
+
+.navItem.active .navLabel {
+  color: #6366f1;
+}
+
+/* 작은 화면 대응 */
+@media (max-width: 375px) {
+  .bottomNavigation {
+    left: 0;
+    transform: none;
+  }
+}

--- a/src/components/HeyMain/HeyHeader/HeyHeader.jsx
+++ b/src/components/HeyMain/HeyHeader/HeyHeader.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import styles from './HeyHeader.module.css';
+
+const HeyHeader = () => {
+  return (
+    <div className={styles.header}>
+      <div className={styles.headerLeft}>
+        <div className={styles.menuIcon}>
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+            <path d="M3 12h18M3 6h18M3 18h18" stroke="white" strokeWidth="2" strokeLinecap="round"/>
+          </svg>
+        </div>
+        <span className={styles.appName}>헤이영대학교</span>
+      </div>
+      <div className={styles.headerRight}>
+        <div className={styles.searchIcon}>
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+            <circle cx="11" cy="11" r="8" stroke="white" strokeWidth="2"/>
+            <path d="m21 21-4.35-4.35" stroke="white" strokeWidth="2" strokeLinecap="round"/>
+          </svg>
+        </div>
+        <div className={styles.moreIcon}>
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+            <circle cx="12" cy="5" r="1" fill="white"/>
+            <circle cx="12" cy="12" r="1" fill="white"/>
+            <circle cx="12" cy="19" r="1" fill="white"/>
+          </svg>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default HeyHeader;

--- a/src/components/HeyMain/HeyHeader/HeyHeader.module.css
+++ b/src/components/HeyMain/HeyHeader/HeyHeader.module.css
@@ -1,0 +1,29 @@
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 50px 20px 20px 20px;
+  color: white;
+}
+
+.headerLeft {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.menuIcon, .searchIcon, .moreIcon {
+  cursor: pointer;
+  padding: 4px;
+}
+
+.appName {
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.headerRight {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}

--- a/src/components/HeyMain/MenuGrid/MenuGrid.jsx
+++ b/src/components/HeyMain/MenuGrid/MenuGrid.jsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import styles from './MenuGrid.module.css';
+
+const MenuGrid = () => {
+  const menuItems = [
+    { icon: '📋', title: '출결 신청내역', id: 'attendance' },
+    { icon: '📅', title: '일정관리', id: 'schedule' },
+    { icon: '🎓', title: '성적 조회', id: 'grades' },
+    { icon: '📚', title: '수강 신청', id: 'registration' },
+    { icon: '🏠', title: '주거 신청', id: 'housing' },
+    { icon: '🔊', title: '공지 사항', id: 'notice' },
+    { icon: '⚙️', title: '환경 설정', id: 'settings' },
+    { icon: '🎯', title: '포인트 관리', id: 'points' },
+    { icon: '💳', title: '학생증 재발급', id: 'card' },
+    { icon: '🏫', title: '시설물 관리', id: 'facility' },
+    { icon: '💰', title: '학습관리', id: 'study' },
+    { icon: '🍽️', title: '식당정보', id: 'dining' }
+  ];
+
+  const renderIcon = (iconType, id) => {
+    const iconMap = {
+      'attendance': (
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+          <rect x="3" y="3" width="18" height="18" rx="2" stroke="#666" strokeWidth="2"/>
+          <path d="M9 12l2 2 4-4" stroke="#666" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+        </svg>
+      ),
+      'schedule': (
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+          <rect x="3" y="4" width="18" height="18" rx="2" ry="2" stroke="#666" strokeWidth="2"/>
+          <line x1="16" y1="2" x2="16" y2="6" stroke="#666" strokeWidth="2" strokeLinecap="round"/>
+          <line x1="8" y1="2" x2="8" y2="6" stroke="#666" strokeWidth="2" strokeLinecap="round"/>
+          <line x1="3" y1="10" x2="21" y2="10" stroke="#666" strokeWidth="2" strokeLinecap="round"/>
+        </svg>
+      ),
+      'grades': (
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+          <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" stroke="#666" strokeWidth="2"/>
+        </svg>
+      ),
+      'registration': (
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+          <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z" stroke="#666" strokeWidth="2"/>
+          <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z" stroke="#666" strokeWidth="2"/>
+        </svg>
+      ),
+      'housing': (
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+          <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" stroke="#666" strokeWidth="2"/>
+          <polyline points="9,22 9,12 15,12 15,22" stroke="#666" strokeWidth="2"/>
+        </svg>
+      ),
+      'notice': (
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+          <path d="M3 11l19-9-9 19-2-8-8-2z" stroke="#666" strokeWidth="2"/>
+        </svg>
+      ),
+      'settings': (
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+          <circle cx="12" cy="12" r="3" stroke="#666" strokeWidth="2"/>
+          <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" stroke="#666" strokeWidth="2"/>
+        </svg>
+      ),
+      'points': (
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+          <circle cx="12" cy="12" r="10" stroke="#666" strokeWidth="2"/>
+          <circle cx="12" cy="12" r="6" fill="#666"/>
+          <circle cx="12" cy="12" r="2" fill="white"/>
+        </svg>
+      ),
+      'card': (
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+          <rect x="1" y="4" width="22" height="16" rx="2" ry="2" stroke="#666" strokeWidth="2"/>
+          <line x1="1" y1="10" x2="23" y2="10" stroke="#666" strokeWidth="2"/>
+        </svg>
+      ),
+      'facility': (
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+          <rect x="2" y="7" width="20" height="14" rx="2" ry="2" stroke="#666" strokeWidth="2"/>
+          <path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16" stroke="#666" strokeWidth="2"/>
+        </svg>
+      ),
+      'study': (
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+          <circle cx="12" cy="12" r="10" stroke="#666" strokeWidth="2"/>
+          <polyline points="12,6 12,12 16,14" stroke="#666" strokeWidth="2"/>
+        </svg>
+      ),
+      'dining': (
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+          <path d="M18 8h1a4 4 0 0 1 0 8h-1" stroke="#666" strokeWidth="2"/>
+          <path d="M2 8h16v9a4 4 0 0 1-4 4H6a4 4 0 0 1-4-4V8z" stroke="#666" strokeWidth="2"/>
+          <line x1="6" y1="1" x2="6" y2="4" stroke="#666" strokeWidth="2"/>
+          <line x1="10" y1="1" x2="10" y2="4" stroke="#666" strokeWidth="2"/>
+          <line x1="14" y1="1" x2="14" y2="4" stroke="#666" strokeWidth="2"/>
+        </svg>
+      )
+    };
+
+    return iconMap[id] || <span style={{fontSize: '24px'}}>{iconType}</span>;
+  };
+
+  return (
+    <div className={styles.menuContainer}>
+      <div className={styles.menuTitle}>MY메뉴</div>
+      <div className={styles.menuGrid}>
+        {menuItems.map((item, index) => (
+          <div key={index} className={styles.menuItem}>
+            <div className={styles.menuIcon}>
+              {renderIcon(item.icon, item.id)}
+            </div>
+            <span className={styles.menuText}>{item.title}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default MenuGrid;

--- a/src/components/HeyMain/MenuGrid/MenuGrid.module.css
+++ b/src/components/HeyMain/MenuGrid/MenuGrid.module.css
@@ -1,0 +1,54 @@
+.menuContainer {
+  background: white;
+  border-radius: 16px;
+  padding: 20px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
+}
+
+.menuTitle {
+  font-size: 16px;
+  font-weight: 600;
+  color: #333;
+  margin-bottom: 20px;
+}
+
+.menuGrid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 20px 5%;
+  
+}
+
+.menuItem {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 8px;
+  transition: background-color 0.2s ease;
+}
+
+.menuItem:hover {
+  background-color: #f8f9fa;
+}
+
+.menuIcon {
+  width: 48px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f8f9fa;
+  border-radius: 12px;
+  margin-bottom: 4px;
+}
+
+.menuText {
+  font-size: 11px;
+  color: #666;
+  text-align: center;
+  line-height: 1.2;
+  font-weight: 400;
+}

--- a/src/components/HeyMain/UserCard/UserCard.jsx
+++ b/src/components/HeyMain/UserCard/UserCard.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import styles from './UserCard.module.css';
+
+const UserCard = () => {
+  return (
+    <div className={styles.userCard}>
+      <div className={styles.userInfo}>
+        <div className={styles.avatar}>
+          <svg width="40" height="40" viewBox="0 0 40 40" fill="none">
+            <circle cx="20" cy="20" r="20" fill="#FF6B6B"/>
+            <circle cx="20" cy="16" r="6" fill="white"/>
+            <path d="M8 32c0-6.627 5.373-12 12-12s12 5.373 12 12" fill="white"/>
+          </svg>
+        </div>
+        <div className={styles.userDetails}>
+          <span className={styles.greeting}>안녕하세요 반갑습니다</span>
+          <span className={styles.userName}>최이영(20220123345)</span>
+        </div>
+      </div>
+      <div className={styles.loginButton}>
+        <span>로그인</span>
+      </div>
+    </div>
+  );
+};
+
+export default UserCard;

--- a/src/components/HeyMain/UserCard/UserCard.module.css
+++ b/src/components/HeyMain/UserCard/UserCard.module.css
@@ -1,0 +1,50 @@
+.userCard {
+  background: white;
+  border-radius: 16px;
+  padding: 20px;
+  margin-bottom: 24px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
+}
+
+.userInfo {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  overflow: hidden;
+}
+
+.userDetails {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.greeting {
+  font-size: 12px;
+  color: #666;
+}
+
+.userName {
+  font-size: 14px;
+  font-weight: 600;
+  color: #333;
+}
+
+.loginButton {
+  background: #6366f1;
+  color: white;
+  padding: 8px 16px;
+  border-radius: 20px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,11 +1,16 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import './index.css';
-import App from './App';
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
+import './index.css'
+import App from './App.jsx'
 
-const root = ReactDOM.createRoot(document.getElementById('root'));
-root.render(
-  <App />
-);
-
-
+createRoot(document.getElementById('root')).render(
+  // <StrictMode>
+  //   <BrowserRouter>
+  //     <App />
+  //   </BrowserRouter>
+  // </StrictMode>,
+  <BrowserRouter>
+    <App />
+  </BrowserRouter>
+)

--- a/src/pages/heyyoung/Main/HeyMainPage.jsx
+++ b/src/pages/heyyoung/Main/HeyMainPage.jsx
@@ -1,0 +1,21 @@
+import Header from '../../../components/HeyMain/HeyHeader/HeyHeader';
+import UserCard from '../../../components/HeyMain/UserCard/UserCard';
+import MenuGrid from '../../../components/HeyMain/MenuGrid/MenuGrid';
+import BottomNavigation from '../../../components/BottomNavigation/BottomNavigation';
+import styles from './HeyMainPage.module.css'
+
+const HeyMainPage = () => {
+
+  return (
+    <div className={styles.app}>
+      <Header />
+      <div className={styles.content}>
+        <UserCard />
+        <MenuGrid />
+      </div>
+      <BottomNavigation />
+    </div>
+  );
+}
+
+export default HeyMainPage;

--- a/src/pages/heyyoung/Main/HeyMainPage.module.css
+++ b/src/pages/heyyoung/Main/HeyMainPage.module.css
@@ -1,0 +1,30 @@
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  margin: 0;
+  padding: 0;
+}
+
+.app {
+  min-height: 100vh;
+  background: linear-gradient(135deg, #7b68ee 0%, #6366f1 100%);
+  max-width: 100wh;
+  margin: 0 auto;
+  position: relative;
+}
+
+.content {
+  padding: 0 20px 20px 20px;
+  flex: 1;
+  padding-bottom: 100px; /* 네비게이션 바 공간 확보 */
+}

--- a/src/pages/solsolhanhankki/Main/SolMainPage.jsx
+++ b/src/pages/solsolhanhankki/Main/SolMainPage.jsx
@@ -1,0 +1,22 @@
+import React, { useEffect } from 'react';
+import Header from '../../../components/Header/Header';
+import Main from '../../../components/Main/Main';
+import { getStoresByCategory } from '../../../util/ddangApi';
+
+const SolMainPage = () => {
+
+  useEffect(() => {
+    getStoresByCategory("36.11176327871577", "03", "128.42631888739962", "4719067000").then(response => {
+      console.log(response);
+    });
+  }, []);
+
+  return (
+    <div className="App">
+      <Header />
+      <Main />  
+    </div>
+  );
+}
+
+export default SolMainPage;

--- a/src/routes/AppRoutes.jsx
+++ b/src/routes/AppRoutes.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Routes, Route } from 'react-router-dom';
+import HeyMainPage from '../pages/heyyoung/Main/HeyMainPage';
+import SolMainPage from '../pages/solsolhanhankki/Main/SolMainPage';
+import WalletMainPage from '../pages/heyyoung/Wallet/WalletMainPage/WalletMainPage';
+import AccountManagePage from '../pages/heyyoung/Wallet/AccountManagePage/AccountManagePage'
+import AccountConnectPage from '../pages/heyyoung/Wallet/AccountConnectPage/AccountConnectPage'
+import VerifyTransactionPage from '../pages/external/VerifyTransactionPage/VerifyTransactionPage';
+
+const AppRoutes = () => {
+  return (
+    <Routes>
+      <Route path="/" element={<HeyMainPage />} />
+      <Route path="/solsol" element={<SolMainPage />} />
+      <Route path="/pay" element={<WalletMainPage />} />
+      <Route path="/account-manage" element={<AccountManagePage />} />
+      <Route path="/account-connect" element={<AccountConnectPage />} />
+      <Route path='/verify-transaction' element={<VerifyTransactionPage />} />
+    </Routes>
+  );
+};
+
+export default AppRoutes;


### PR DESCRIPTION
### 변경 내용
- `react-router-dom`을 이용해 페이지 라우팅을 적용했습니다.
  - routers/AppRouter.jsx 에 라우팅 정보를 작성하고
  - App.jsx 에서 AppRouter를 import 하여 적용합니다.
- 기존 웰컴페이지로 동작하던 쏠쏠한 한끼 메인페이지를 pages/SolMainPage로 이동시켰습니다.
- 헤이영 메인페이지를 1차로 구현했습니다. 추후 디자인 수정이 필요할 것 같습니다.
- 하단 navigation을 통해 페이머니(Wallet) 관련 페이지로 이동하도록 구현했습니다.
---
### To Reviewer
- 바뀐 디렉토리 구조에서는 page와 component를 구분하고 있습니다 

+) 로그인 폼이 추가로 필요할 것 같습니다. 테스트 계정을 10개 정도 만들어 두고, 각각의 계정으로 테스트할 수 있어야 할 것 같기 때문입니다.

+) router에 wallet 관련 파일을 import 하고 있는데, 이번 커밋에는 해당 파일이 포함되지 않아 오류가 발생할 수 있습니다.  주석 처리 후 개발 진행해주세요

---
### 관련 이슈
- resolves #10 